### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/utils/tar.go
+++ b/utils/tar.go
@@ -145,6 +145,12 @@ func TargzVerify(name, src string) error {
 				dest, err.Error())
 		}
 
+		// Validate that the file path does not contain ".."
+		if strings.Contains(h.Name, "..") {
+			return fmt.Errorf("Invalid file path '%s' in archive '%s'. Path traversal detected.",
+				h.Name, dest)
+		}
+
 		fi, ok := fimap[h.Name]
 		if ok {
 			if fi.Mode().IsRegular() && fi.Size() != h.Size {


### PR DESCRIPTION
Fixes [https://github.com/jzoran/ghorgs/security/code-scanning/1](https://github.com/jzoran/ghorgs/security/code-scanning/1)

To fix the problem, we need to ensure that the file paths extracted from the tar archive do not contain any directory traversal elements like `..`. This can be achieved by validating the paths before using them in any file system operations.

The best way to fix this issue without changing existing functionality is to add a check to ensure that the file paths do not contain `..` before proceeding with any file system operations. We will use the `strings.Contains` function to check for the presence of `..` in the file paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
